### PR TITLE
alg-132: fix price/amount overlap on windows/chrome

### DIFF
--- a/components/order-input/order-input.css.js
+++ b/components/order-input/order-input.css.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 
 export const Input = styled.input`
   flex: 1 1 auto;
+  width: 100%;
   background-color: ${({ theme }) => theme.colors.gray['900']};
   border: 2px solid ${({ theme }) => theme.colors.gray['700']};
   border-radius: 3px;


### PR DESCRIPTION
For some reason the container extends beyond the viewport on windows/chrome. Tested on both windows/mac. 

![image](https://user-images.githubusercontent.com/40471143/122474111-fef1fc80-cf7f-11eb-97ba-b15084942e3b.png)
