### PR TITLE
Update Jest config to support React Query

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   setupFilesAfterEnv: ['./jest.setup.js'],
-  moduleDirectories: ['node_modules', '.'],
+  moduleDirectories: ['node_modules', '<rootDir>'],
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^components(.*)$': '<rootDir>/components$1',

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,9 +1,16 @@
 /* eslint-disable react/prop-types */
 import { render } from '@testing-library/react'
 import { ThemeProvider } from 'styled-components'
+import { QueryClient, QueryClientProvider } from 'react-query'
 import theme from '../theme'
 
-const Providers = ({ children }) => <ThemeProvider theme={theme}>{children}</ThemeProvider>
+const queryClient = new QueryClient()
+
+const Providers = ({ children }) => (
+  <ThemeProvider theme={theme}>
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  </ThemeProvider>
+)
 
 const customRender = (ui, options = {}) => render(ui, { wrapper: Providers, ...options })
 


### PR DESCRIPTION
This fixes two issues with Jest caused by introducing React Query.

1. Adds `QueryClientProvider` to our providers in `test/test-utils.js`
2. Changes `moduleDirectories` option in Jest config due to a bug explained here: https://github.com/blitz-js/blitz/pull/1323

Closes ALG-147