### PR TITLE
ALG-153: Fix Storybook error on reload after save

### DIFF
--- a/components/hamburger/hamburger.stories.js
+++ b/components/hamburger/hamburger.stories.js
@@ -23,6 +23,8 @@ export default {
   ]
 }
 
+const Template = (args) => <Hamburger {...args} />
+
 export const Default = Template.bind({})
 Default.args = {
   isOpen: false


### PR DESCRIPTION
This pesky error has prevented me from using Storybook for weeks lol, finally had enough and inspected every `*.stories.js` file line by line