### PR TITLE
Only reset order book when switching the current asset

### DIFF
--- a/store/use-store.js
+++ b/store/use-store.js
@@ -29,9 +29,18 @@ export const useStorePersisted = create(
 )
 
 export const useStore = create(
-  immer((set) => ({
+  immer((set, get) => ({
     asset: {},
-    setAsset: (asset) => set({ asset, orderBook: { buyOrders: [], sellOrders: [] } }),
+    setAsset: (asset) => {
+      const prevAsset = get().asset
+      const isNew = prevAsset.id !== asset.id
+      const orderBook = { buyOrders: [], sellOrders: [] }
+
+      set({
+        asset,
+        ...(isNew ? orderBook : {}) // only reset order book if asset is new
+      })
+    },
 
     isSignedIn: false,
     setIsSignedIn: (isSignedIn) => set({ isSignedIn }),


### PR DESCRIPTION
When switching to a new asset the order book should be reset... but `setAsset` is also called when the current asset changes (like when the price changes). Check that this is a new asset before resetting the order book.

Closes ALG-415