### PR TITLE
Condense long unit names in order form

### DIFF
--- a/components/order-input/index.jsx
+++ b/components/order-input/index.jsx
@@ -2,11 +2,13 @@ import PropTypes from 'prop-types'
 import { Container, Input, Label, Asset } from './order-input.css'
 
 function OrderInput({ label, asset, orderType, ...props }) {
+  const condenseAssetName = asset?.length > 5
+
   return (
     <Container orderType={orderType}>
       <Input placeholder="0.00" {...props} />
       <Label>{label}</Label>
-      <Asset>{asset}</Asset>
+      <Asset isCondensed={condenseAssetName}>{asset}</Asset>
     </Container>
   )
 }

--- a/components/order-input/order-input.css.js
+++ b/components/order-input/order-input.css.js
@@ -64,4 +64,5 @@ export const Label = styled(InputLabel)`
 export const Asset = styled(InputLabel)`
   right: 1.25rem;
   width: 2.75rem;
+  font-family: ${({ isCondensed }) => (isCondensed ? `'Open Sans Condensed'` : 'inherit')};
 `

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -34,7 +34,7 @@ export default class MyDocument extends Document {
           <link rel="preconnect" href="https://fonts.gstatic.com" />
           <link
             rel="stylesheet"
-            href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Open+Sans+Condensed:wght@700&display=swap"
           />
           <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
           <link rel="stylesheet" href="/fonts/style.css" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1054794/130362638-1b2525fc-896b-4bc6-9782-61fa80c7ede1.png)

Using [Open Sans Condensed Bold](https://fonts.google.com/specimen/Open+Sans+Condensed), since Inter does not offer a condensed version

Closes ALG-400