### PR TITLE
Add correct colors for buy vs sell orders

### DIFF
--- a/components/open-orders/index.jsx
+++ b/components/open-orders/index.jsx
@@ -57,7 +57,7 @@ function OpenOrders() {
     return (<Link href={`/trade/${assetId}`}><OrderPair>{value}</OrderPair></Link>)
   }
 
-  const OrderTypeCell = ({ value }) => <OrderType value={value}>{value}</OrderType>
+  const OrderTypeCell = ({ value }) => <OrderType value={value}>{t(value.toLowerCase())}</OrderType>
 
   const OrderAmountCell = ({ value }) => <OrderAmount>{value}</OrderAmount>
 

--- a/components/order-history/helpers.js
+++ b/components/order-history/helpers.js
@@ -1,7 +1,9 @@
 import dayjs from 'dayjs'
 import { floatToFixed } from 'services/display'
 
-export const mapTradeHistoryData = (data, { buyText = "BUY", sellText = "SELL"}) => {
+export const mapTradeHistoryData = (data) => {
+  const buyText = 'BUY'
+  const sellText = 'SELL'
   if (!data || !data.transactions || !data.allAssets) {
     return null
   }

--- a/components/order-history/index.jsx
+++ b/components/order-history/index.jsx
@@ -27,14 +27,16 @@ const OrderPairCell = ({ value, row }) => {
   return (<Link href={`/trade/${assetId}`}><OrderPair>{value}</OrderPair></Link>)
 }
 
-const OrderSideCell = ({ value }) => <OrderSide value={value}>{value}</OrderSide>
 
 const OrderPriceCell = ({ value }) => <OrderPrice>{value}</OrderPrice>
 
 const OrderAmountCell = ({ value }) => <OrderAmount>{value}</OrderAmount>
 
 function OrderHistory() {
-  const { t, lang } = useTranslation("orders");
+  const { t, lang } = useTranslation('orders')
+  
+  const OrderSideCell = ({ value }) => <OrderSide value={value}>{t(value.toLowerCase())}</OrderSide>
+
   const activeWalletAddress = useStorePersisted((state) => state.activeWalletAddress)
 
   const { data, isLoading, isError } = useQuery(
@@ -45,8 +47,7 @@ function OrderHistory() {
       refetchInterval: 3000
     }
   )
-
-  const tradeHistoryData = useMemo(() => mapTradeHistoryData(data, { buyText: t("buy"), sellText: t("sell")}), [data, lang])
+  const tradeHistoryData = useMemo(() => mapTradeHistoryData(data), [data, lang])
 
   const columns = useMemo(
     () => [


### PR DESCRIPTION
# Description

The problem is that buy orders and sell orders need to show in green vs red for foreign languages. Everything was displaying in red.