### PR TITLE
Remove the history button. It will be refactored into the orders tab

### DIFF
--- a/components/main-layout/index.jsx
+++ b/components/main-layout/index.jsx
@@ -82,11 +82,9 @@ function MainLayout({ asset, children }) {
         <AssetOrderBookSection active={activeMobile === TABS.BOOK}>
           <OrderBook asset={asset} />
         </AssetOrderBookSection>
-
         <AssetTradeHistorySection active={activeMobile === TABS.HISTORY}>
           <TradeHistory asset={asset} />
         </AssetTradeHistorySection>
-
         <WalletOrdersSection active={activeMobile === TABS.ORDERS}>
           <Orders />
         </WalletOrdersSection>
@@ -128,11 +126,14 @@ function MainLayout({ asset, children }) {
                 {t('mobilefooter-ORDERS')}
               </MobileMenuButton>
             </li>
+            {/*
             <li>
+              // Trade history. Disable for now until it is refactored into the Orders tab
               <MobileMenuButton type="button" onClick={() => setActiveMobile(TABS.HISTORY)}>
                 History
               </MobileMenuButton>
             </li>
+            */}
             <li>
               <MobileMenuButton
                 type="button"

--- a/components/main-layout/main-layout.css.js
+++ b/components/main-layout/main-layout.css.js
@@ -197,7 +197,7 @@ export const MobileMenuButton = styled(Button)`
   background-color: ${({ theme }) => theme.colors.gray['800']};
   padding: 0;
   border: 1px solid ${({ theme }) => theme.colors.gray['700']};
-  max-width: ${({ characterLength }) => (characterLength > 8 ? '4rem' : '5rem')};
+  max-width: ${({ characterLength }) => (characterLength > 8 ? '4rem' : '7rem')};
   min-width: ${({ characterLength }) => (characterLength > 8 ? '3.5rem' : '3.5rem')};
   font-size: ${({ characterLength }) => (characterLength > 6 ? '10px' : '0.875rem')};
   overflow-wrap: anywhere;


### PR DESCRIPTION
# ℹ Overview

The History button currently adds too much clutter and the bottom tabs should have 5 buttons, not 6. The history button is also strictly not necessary for mobile usage.

It will also be refactored into the orders tab (Adesola is working on this).


- [x] `yarn test` passes
- [ ] Uses Unicode conventional commits [gitmoji](https://gitmoji.dev/)
