### PR TITLE
:sparkles: Fix support for toggling between testnet and mainnet

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -12,5 +12,6 @@ NEXT_PUBLIC_ALGORAND_INDEXER_API=https://algoexplorerapi.io/idx2
 NEXT_PUBLIC_EXPLORER_INDEXER_API=https://algoindexer.algoexplorerapi.io
 NEXT_PUBLIC_EXPLORER_API=https://node.algoexplorerapi.io
 NEXT_PUBLIC_ALGO_EXPLORER_V1_API=https://algoexplorerapi.io
-
+NEXT_PUBLIC_MAINNET_LINK=https://algodex-react-93gka5c7s-algodex-mainnet.vercel.app
+NEXT_PUBLIC_TESTNET_LINK=https://testnet.algodex.com
 GEO_PASSWORD=Password

--- a/components/header/header.css.js
+++ b/components/header/header.css.js
@@ -266,3 +266,8 @@ export const NetworkDropdown = styled.select`
   border-radius: 3px;
   padding: 0.3rem 0.5rem;
 `
+
+export const NetworkDropdownOption = styled.option`
+  color: ${({ enableLinks }) =>
+    enableLinks ? 'black' : '#AAA'};
+`

--- a/components/header/index.jsx
+++ b/components/header/index.jsx
@@ -7,7 +7,8 @@ import {
   NavTextLg,
   NavTextSm,
   Navigation,
-  NetworkDropdown
+  NetworkDropdown,
+  NetworkDropdownOption
 } from './header.css'
 import { useCallback, useState } from 'react'
 
@@ -20,6 +21,11 @@ import useTranslation from 'next-translate/useTranslation'
 import useUserStore from 'store/use-user-state'
 import { withRouter } from 'next/router'
 
+const ENABLE_NETWORK_SELECTION =
+  process.env.NEXT_PUBLIC_TESTNET_LINK && process.env.NEXT_PUBLIC_MAINNET_LINK
+const MAINNET_LINK = process.env.NEXT_PUBLIC_MAINNET_LINK
+const TESTNET_LINK = process.env.NEXT_PUBLIC_TESTNET_LINK
+
 export function Header({ router }) {
   const [isOpen, setIsOpen] = useState(false)
   const activeNetwork = useUserStore((state) => state.activeNetwork)
@@ -31,9 +37,13 @@ export function Header({ router }) {
    */
   const handleNetworkChangeFn = useCallback(
     (value) => {
-      if (activeNetwork !== value) {
-        // This can also be window.location =
-        router.push(window.location.href.replace(activeNetwork, value))
+      if (!ENABLE_NETWORK_SELECTION) {
+        return
+      }
+      if (value === 'mainnet') {
+        window.location = MAINNET_LINK
+      } else {
+        window.location = TESTNET_LINK
       }
     },
     [router, activeNetwork]
@@ -53,10 +63,12 @@ export function Header({ router }) {
         value={activeNetwork}
         onChange={(e) => handleNetworkChangeFn(e.target.value)}
       >
-        <option value="testnet">TESTNET</option>
-        <option disabled value="mainnet">
+        <NetworkDropdownOption value="testnet" enableLinks={ENABLE_NETWORK_SELECTION}>
+          TESTNET
+        </NetworkDropdownOption>
+        <NetworkDropdownOption value="mainnet" enableLinks={ENABLE_NETWORK_SELECTION}>
           MAINNET
-        </option>
+        </NetworkDropdownOption>
       </NetworkDropdown>
       <Navigation>
         <ActiveLink href="/about" matches={/^\/about/}>


### PR DESCRIPTION
# ℹ Overview

Fix support for toggling between Mainnet and Testnet.

This adds two new environment variables:

NEXT_PUBLIC_MAINNET_LINK
NEXT_PUBLIC_TESTNET_LINK

If both are set, the switching is enabled. If either is unset, it is disabled and allows for Testnet only selection.

