### PR TITLE
🐛 Fix Infinity price for market orders

### DIFF
--- a/components/place-order/view.jsx
+++ b/components/place-order/view.jsx
@@ -173,7 +173,7 @@ function PlaceOrderView(props) {
         )
       }
     }
-  }, [setOrder, order, asset, marketBuyPrice, marketSellPrice])
+  }, [setOrder, order.type, asset, marketBuyPrice, marketSellPrice])
 
   useEffect(() => {
     if (orderView === MARKET_PANEL) {
@@ -181,18 +181,24 @@ function PlaceOrderView(props) {
     }
   }, [assetOrders, order.type, marketBuyPrice, marketSellPrice, handleMarketOrderChange, orderView])
 
-  const handleRangeChange = (update) => {
-    setOrder(update, asset)
-  }
+  const handleRangeChange = useCallback(
+    (update) => {
+      setOrder(update, asset)
+    },
+    [setOrder, asset]
+  )
 
-  const handleOptionsChange = (e) => {
-    setOrder(
-      {
-        execution: e.target.value
-      },
-      asset
-    )
-  }
+  const handleOptionsChange = useCallback(
+    (e) => {
+      setOrder(
+        {
+          execution: e.target.value
+        },
+        asset
+      )
+    },
+    [setOrder, asset]
+  )
 
   const placeOrder = (orderData) => {
     // Filter buy and sell orders to only include orders with a microalgo amount greater than the set filter amount


### PR DESCRIPTION
# ℹ Overview

Clicking on Market Tab throws Big.js error. This ensures we do not use Infinity as a price in `setOrder` for handling Market Orders.


 Error appears for this asset:

https://testnet.algodex.com/trade/69410904

### 🔐 Acceptance:
<!-- Ensure the following are completed and mark the result with an [X] -->

- [ ] `yarn test` passes
- [X] Uses Unicode conventional commits [gitmoji](https://gitmoji.dev/)
