### PR TITLE
Updated flag for the Catalan language 

### DIFF
--- a/components/header/index.jsx
+++ b/components/header/index.jsx
@@ -45,6 +45,8 @@ const localeToFlags = {
   fr: 'FR',
   pl: 'PL'
 }
+
+
 const ENABLE_NETWORK_SELECTION =
   process.env.NEXT_PUBLIC_TESTNET_LINK && process.env.NEXT_PUBLIC_MAINNET_LINK
 const MAINNET_LINK = process.env.NEXT_PUBLIC_MAINNET_LINK

--- a/components/language-selection/index.jsx
+++ b/components/language-selection/index.jsx
@@ -38,7 +38,7 @@ const localeToFlags = {
   sk: 'SK',
   hu: 'HU',
   no: 'NO',
-  ct: 'ES',
+  ct: 'ES-CT',
   th: 'TH',
   in: 'IN',
   de: 'DE',


### PR DESCRIPTION
# ℹ Overview

The flag for the Catalan language has been fixed to the accurate flag. 

### 🔐 Acceptance:
<!-- Ensure the following are completed and mark the result with an [X] -->

- [ X] `yarn test` passes
- [ X] Uses Unicode conventional commits [gitmoji](https://gitmoji.dev/)
