### PR TITLE
:bug: Order Book and Trade History label in mobile size window

### DIFF
--- a/components/Asset/HistoryAndOrders/index.jsx
+++ b/components/Asset/HistoryAndOrders/index.jsx
@@ -50,7 +50,7 @@ const Container = styled.div`
   flex: 1 1 0%;
 `
 function HistoryAndOrderBook({ asset, isMobile }) {
-  const { t } = useTranslation('orders')
+  const { t } = useTranslation('common')
   const [selectedPanel, setSelectedPanel] = useState('order-book')
   const ORDER_BOOK_PANEL = 'order-book'
   const TRADE_HISTORY_PANEL = 'trade-history'


### PR DESCRIPTION
# ℹ Overview

change `ORDER-BOOK` TO `ORDER BOOK` and `TRADE-HISTORY` to `TRAIDE HISTORY` in mobile size window

### 📝 Related Issues

- https://github.com/algodex/algodex-react/issues/543

### 🔐 Acceptance:
<!-- Ensure the following are completed and mark the result with an [X] -->

- [ ] `yarn test` passes
- [ ] Uses Unicode conventional commits [gitmoji](https://gitmoji.dev/)
