### PR TITLE
fix: remove total as it's useless

### DIFF
--- a/components/Wallet/PlaceOrder/Original/helpers.js
+++ b/components/Wallet/PlaceOrder/Original/helpers.js
@@ -10,7 +10,6 @@ export const customAggregator = (order, decimals) => {
 
 export const aggregateOrders = (orders, asaDecimals, type) => {
   const isBuyOrder = type === 'buy'
-  // let total = 0
   const leftPriceDecimalsLength = orders.map((order) => {
     const price = new BigJS(convertFromAsaUnits(order.asaPrice, asaDecimals))
     const left = Math.floor(price)
@@ -38,8 +37,6 @@ export const aggregateOrders = (orders, asaDecimals, type) => {
       ? calculateAsaBuyAmount(price, orderAmount)
       : parseFloat(order.formattedASAAmount)
 
-    // total += amount
-
     const index = result.findIndex((obj) => obj.price === price)
 
     if (index !== -1) {
@@ -51,7 +48,6 @@ export const aggregateOrders = (orders, asaDecimals, type) => {
     const model = {
       price,
       amount
-      // total
     }
 
     result.push(model)


### PR DESCRIPTION
# ℹ Overview

Issue currently solved to 95% precision. Following is the explanation for the 5%:

<img width="281" alt="accuracy-issue" src="https://user-images.githubusercontent.com/7276756/174835381-771ce318-774e-4a9d-aef3-bc1db294fdb2.png">

Here **10.4** is the `price` whereas **0.127** is the `amount` and the total returned is **1.3208**. Following is the output table:

| Arithmetic Type | Price | Amount | Total  | Accuracy |
|-----------------|-------|--------|--------|----------|
| Actual          | 10.4  | 0.127  | 1.3208 | 100%     |
| Computed        | 10.4  | 0.127  | 1.326  | 95%      |
| Difference      | 1.326 | 1.3208 | 0.0052 | 5%       |

### 📝 Related Issues

<!--- Pin any related issues -->

### 🔐 Acceptance:
<!-- Ensure the following are completed and mark the result with an [X] -->

- [ ] `yarn test` passes
- [ ] Uses Unicode conventional commits [gitmoji](https://gitmoji.dev/)
