### PR TITLE
Changed implementation details of create address component

### DIFF
--- a/components/LaunchPad/CreatorAddress.tsx
+++ b/components/LaunchPad/CreatorAddress.tsx
@@ -9,13 +9,20 @@ import Button from '@mui/material/Button'
 import { CopyIcon } from './copyIcon'
 import { truncatedWalletAddress } from 'components/helpers'
 import { styles } from './styles.css'
+import useWallets from '@/hooks/useWallets'
 
 type creatorAddressTypes = {
-  address?: string
+  activeWallet?: any
 }
 
-export const CreatorAddress = ({ address }: creatorAddressTypes) => {
-  const isConnected = typeof address !== 'undefined'
+export const CreatorAddress = ({ activeWallet }: creatorAddressTypes) => {
+  const { peraDisconnect, myAlgoDisconnect } = useWallets(null)
+  const walletDisconnectMap = {
+    'my-algo-wallet': myAlgoDisconnect,
+    'wallet-connect': peraDisconnect
+  }
+
+  const isConnected = typeof activeWallet !== 'undefined'
   return (
     <>
       <Box
@@ -40,9 +47,9 @@ export const CreatorAddress = ({ address }: creatorAddressTypes) => {
                 fontWeight: 500
               }}
             >
-              {truncatedWalletAddress(address, 4)}
+              {truncatedWalletAddress(activeWallet.address, 4)}
             </Typography>
-            <CopyIcon content={address} />
+            <CopyIcon content={activeWallet.address} />
           </>
         ) : (
           <Typography
@@ -60,13 +67,16 @@ export const CreatorAddress = ({ address }: creatorAddressTypes) => {
       {isConnected && (
         <Button
           type="button"
+          onClick={() => {
+            walletDisconnectMap[activeWallet.type](activeWallet)
+          }}
           sx={{
             color: 'white',
             backgroundColor: 'gray.150',
             px: '10px',
             py: '1px',
             fontWeight: 500,
-            fontSize:'12px',
+            fontSize: '12px',
             border: '2px solid',
             transition: 'all ease .3s',
             '&:hover': {

--- a/components/LaunchPad/Sale/CreateTokenSale.tsx
+++ b/components/LaunchPad/Sale/CreateTokenSale.tsx
@@ -69,7 +69,7 @@ export const CreateTokenSale = () => {
         <Typography variant="body1" sx={{ fontWeight: 600, color: 'white', lineHeight: 1.2 }}>
           Creator/Reserve Address:
         </Typography>
-        <CreatorAddress address={activeWallet?.address} />
+        <CreatorAddress activeWallet={activeWallet ? activeWallet : undefined} />
       </Box>
       <Typography variant="body1" sx={{ ...styles.body1, marginBottom: '24px' }}>
         A sale must be started from either the Creator or the Reserve wallet of the ASA. Ensure the

--- a/components/LaunchPad/Sale/ManageTokenSale.tsx
+++ b/components/LaunchPad/Sale/ManageTokenSale.tsx
@@ -36,7 +36,7 @@ const initialValues = {
   pricePerToken: 0.75,
   showPricePerToken: false,
   totalForSale: 14600,
-  showTotalForSale: false,
+  showTotalForSale: false
 }
 
 export const ManageTokenSale = () => {
@@ -78,7 +78,7 @@ export const ManageTokenSale = () => {
         <Typography variant="body1" sx={{ fontWeight: 600, color: 'white', lineHeight: 1.2 }}>
           Creator Address:
         </Typography>
-        <CreatorAddress address={activeWallet?.address} />
+        <CreatorAddress activeWallet={activeWallet ? activeWallet : undefined} />
       </Box>
       <Typography variant="body1" sx={{ ...styles.body1, marginBottom: '30px' }}>
         You can only manage sales that have been created with the connected wallet. If you do not

--- a/components/LaunchPad/Token/CreateToken.tsx
+++ b/components/LaunchPad/Token/CreateToken.tsx
@@ -259,7 +259,7 @@ export const CreateToken = () => {
         <Typography variant="body1" sx={{ fontWeight: 600, color: 'white', lineHeight: 1.2 }}>
           Creator Address:
         </Typography>
-        <CreatorAddress address={activeWallet?.address} />
+        <CreatorAddress activeWallet={activeWallet ? activeWallet : undefined} />
       </Box>
       <Typography variant="body1" sx={{ ...styles.body1, marginBottom: '24px' }}>
         Creator Address defaults to the wallet that’s currently connected. If you want to create an

--- a/components/LaunchPad/Token/ManageToken.tsx
+++ b/components/LaunchPad/Token/ManageToken.tsx
@@ -133,7 +133,7 @@ export const ManageToken = () => {
         <Typography variant="body1" sx={{ fontWeight: 600, color: 'white', lineHeight: 1.2 }}>
           Creator Address:
         </Typography>
-        <CreatorAddress address={activeWallet?.address} />
+        <CreatorAddress activeWallet={activeWallet ? activeWallet : undefined} />
       </Box>
       <Typography variant="body1" sx={{ ...styles.body1, marginBottom: '30px' }}>
         You can only manage ASAs that have been created with the connected wallet. If you do not see


### PR DESCRIPTION
# ℹ Overview

- added disconnect map to `CreatorAddress` component
- `CreatorAddress` component now takes in an activeWallet object not just an address
- updated all launchpad pages to pass in activeWallet or undefined if not connected


### 📝 Related Issues

#993 

### 🔐 Acceptance:
<!-- Ensure the following are completed and mark the result with an [X] -->

- [ ] `yarn test` passes
